### PR TITLE
Add webpack-build-notifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ts-loader": "^0.8.2",
     "typescript": "^1.8.10",
     "typings": "^1.3.1",
-    "webpack": "^1.13.1"
+    "webpack": "^1.13.1",
+    "webpack-build-notifier": "^0.1.11"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+var WebpackBuildNotifierPlugin = require("webpack-build-notifier");
+
 module.exports = {
     entry: "./src/index.tsx",
     output: {
@@ -32,4 +34,8 @@ module.exports = {
         "react": "React",
         "react-dom": "ReactDOM"
     },
+
+    plugins: [
+        new WebpackBuildNotifierPlugin({"sound": false})
+    ],
 };


### PR DESCRIPTION
It makes development more fun by providing an instant feedback on current build status. Works awesome together with `nom run build:w`.
