### PR TITLE
Feature 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ All builds are hosted on [GitHub Pages](http://barushev.net/shaper).
 - [x] The user can drag shapes from the palette and drop them onto the drawing canvas
 - [x] The user can select and move a shape from its current position to another position on the canvas
 - [x] The drawing canvas allows shapes to overlap each other, placing the latest shape on top of previous shapes
-- [ ] The user can change the z-order of shapes, bringing individual shapes forward or pushing them back
+- [x] The user can change the z-order of shapes, bringing individual shapes forward or pushing them back

--- a/src/actions.ts
+++ b/src/actions.ts
@@ -4,6 +4,7 @@ import {ShapeType} from "./models/shape.ts";
 
 export const ADD_SHAPE = "ADD_SHAPE";
 export const MOVE_SHAPE = "MOVE_SHAPE";
+export const BRING_SHAPE_FORWARD = "BRING_SHAPE_FORWARD";
 
 export interface AddShapeAction extends Action {
   shapeType: ShapeType;
@@ -12,6 +13,12 @@ export interface AddShapeAction extends Action {
 }
 
 export interface MoveShapeAction extends Action {
+  shapeIndex: number;
+  x: number;
+  y: number;
+}
+
+export interface BringShapeForwardAction extends Action {
   shapeIndex: number;
   x: number;
   y: number;
@@ -29,6 +36,15 @@ export function addShape(shapeType: ShapeType, x: number, y: number): AddShapeAc
 export function moveShape(shapeIndex: number, x: number, y: number): MoveShapeAction {
   return {
     type: MOVE_SHAPE,
+    shapeIndex,
+    x: x,
+    y: y
+  }
+}
+
+export function bringShapeForward(shapeIndex: number, x: number, y: number): BringShapeForwardAction {
+  return {
+    type: BRING_SHAPE_FORWARD,
     shapeIndex,
     x: x,
     y: y

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -8,6 +8,7 @@ export interface CanvasProps {
   shapes: models.Shape[];
   onDrop: (shapeType: models.ShapeType, x: number, y: number) => void;
   onMouseMove: (shapeId: number, x: number, y: number) => void;
+  onDoubleClick: (shapeId: number, x: number, y: number) => void;
 }
 
 export class Canvas extends React.Component<CanvasProps, {}> {
@@ -34,6 +35,7 @@ export class Canvas extends React.Component<CanvasProps, {}> {
               shape={shape}
               key={i}
               onMouseDown={(shape, e) => {this.shapeMouseDown(shape, e)}}
+              onDoubleClick={(shape, e) => {this.shapeDoubleClick(shape, e)}}
             />
           })
         }
@@ -60,6 +62,11 @@ export class Canvas extends React.Component<CanvasProps, {}> {
 
     window.addEventListener("mousemove", this.windowMouseMove);
     window.addEventListener("mouseup", this.windowMouseUp);
+  }
+
+  private shapeDoubleClick(shape: models.Shape, event: React.MouseEvent) {
+    let {x, y} = this.getEventCoordinates(event);
+    this.props.onDoubleClick(this.props.shapes.indexOf(shape), x - this.draggingShapeOffsetX, y - this.draggingShapeOffsetY);
   }
 
   private windowMouseMove(event: MouseEvent) {

--- a/src/components/CanvasItem.tsx
+++ b/src/components/CanvasItem.tsx
@@ -9,12 +9,14 @@ import * as models from "../models.ts";
 export interface CanvasItemProps {
   shape: models.Shape;
   onMouseDown?: (shape: models.Shape, event: React.MouseEvent) => void;
+  onDoubleClick?: (shape: models.Shape, event: React.MouseEvent) => void;
 }
 
 export class CanvasItem extends React.Component<CanvasItemProps, {}> {
   render() {
     return <g
       onMouseDown={(e) => {this.onMouseDown(e)}}
+      onDoubleClick={(e) => {this.onDoubleClick(e)}}
     >
       {this.renderShape(this.props.shape)}
     </g>;
@@ -33,6 +35,12 @@ export class CanvasItem extends React.Component<CanvasItemProps, {}> {
   private onMouseDown(event: React.MouseEvent) {
     if (this.props.onMouseDown) {
       this.props.onMouseDown(this.props.shape, event);
+    }
+  }
+
+  private onDoubleClick(event: React.MouseEvent) {
+    if (this.props.onDoubleClick) {
+      this.props.onDoubleClick(this.props.shape, event);
     }
   }
 }

--- a/src/containers/CanvasShapes.ts
+++ b/src/containers/CanvasShapes.ts
@@ -2,7 +2,7 @@ import {connect} from "react-redux";
 import {Dispatch} from "redux";
 
 import {State} from "../state.ts";
-import {addShape, moveShape} from "../actions.ts";
+import {addShape, moveShape, bringShapeForward} from "../actions.ts";
 import {ShapeType} from "../models/shape.ts";
 import {Canvas} from "../components/canvas.tsx";
 
@@ -19,6 +19,9 @@ function mapDispatchToProps(dispatch: Dispatch<State>) {
     },
     onMouseMove: (shapeId: number, x: number, y: number) => {
       dispatch(moveShape(shapeId, x, y));
+    },
+    onDoubleClick: (shapeId: number, x: number, y: number) => {
+      dispatch(bringShapeForward(shapeId, x, y));
     }
   }
 }

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -2,7 +2,7 @@ import {Action} from "redux";
 
 import * as models from "./models.ts";
 import {State} from "./state.ts";
-import {ADD_SHAPE, MOVE_SHAPE, AddShapeAction, MoveShapeAction} from "./actions.ts";
+import {ADD_SHAPE, MOVE_SHAPE, BRING_SHAPE_FORWARD, AddShapeAction, MoveShapeAction, BringShapeForwardAction} from "./actions.ts";
 
 const initialState: State = {
   shapes: []
@@ -14,6 +14,8 @@ export function shaperApp(state: State = initialState, action: Action): State {
       return addShape(state, action as AddShapeAction);
     case MOVE_SHAPE:
       return moveShape(state, action as MoveShapeAction);
+    case BRING_SHAPE_FORWARD:
+      return bringShapeForward(state, action as BringShapeForwardAction)
     default:
       return state;
   }
@@ -49,5 +51,11 @@ function moveShape(state: State, action: MoveShapeAction) {
         return shape;
       }
     })
+  });
+}
+
+function bringShapeForward(state: State, action: BringShapeForwardAction) {
+  return Object.assign({}, state, {
+    shapes: [...state.shapes, state.shapes[action.shapeIndex]]
   });
 }

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -56,6 +56,9 @@ function moveShape(state: State, action: MoveShapeAction) {
 
 function bringShapeForward(state: State, action: BringShapeForwardAction) {
   return Object.assign({}, state, {
-    shapes: [...state.shapes, state.shapes[action.shapeIndex]]
+    shapes: [
+      ...state.shapes.filter((shape, index) => index !== action.shapeIndex),
+      state.shapes[action.shapeIndex]
+    ]
   });
 }


### PR DESCRIPTION
The user can change the z-order of shapes, bringing individual shapes forward or pushing them back.

Build: http://barushev.net/shaper/builds/7/

What's done:
- Added new Redux action to allow bringing shapes forward by double clicking on them.
